### PR TITLE
Use Java 11 in CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,17 +15,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Java 11
+      - name: Setup Java 17
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
 
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
 
-      - name: sbt & Paradox
-        run: sbt test docs/paradox
+      - name: sbt test
+        run: sbt test
 
       - name: Maven
         run: |-
@@ -34,3 +34,24 @@ jobs:
       - name: Gradle
         run: |-
           sbt new file://$PWD --name=hello-world --force && pushd hello-world &&  ./gradlew --console=plain build
+
+    build-docs:
+      if: github.repository == 'apache/incubator-pekko-http-quickstart-java.g8'
+      runs-on: ubuntu-20.04
+  
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+  
+        - name: Setup Java 11
+          uses: actions/setup-java@v4
+          with:
+            distribution: temurin
+            java-version: 11
+  
+        - name: Cache Coursier cache
+          uses: coursier/cache-action@v6.4.0
+  
+        - name: sbt & Paradox
+          run: sbt test docs/paradox
+  

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up JDK 17
-        uses: coursier/setup-action@v1.3.0
+      - name: Setup Java 11
+        uses: actions/setup-java@v4
         with:
-          jvm: temurin:1.17
+          distribution: temurin
+          java-version: 11
 
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,23 +35,22 @@ jobs:
         run: |-
           sbt new file://$PWD --name=hello-world --force && pushd hello-world &&  ./gradlew --console=plain build
 
-    build-docs:
-      if: github.repository == 'apache/incubator-pekko-http-quickstart-java.g8'
-      runs-on: ubuntu-20.04
-  
-      steps:
-        - name: Checkout
-          uses: actions/checkout@v4
-  
-        - name: Setup Java 11
-          uses: actions/setup-java@v4
-          with:
-            distribution: temurin
-            java-version: 11
-  
-        - name: Cache Coursier cache
-          uses: coursier/cache-action@v6.4.0
-  
-        - name: sbt & Paradox
-          run: sbt test docs/paradox
-  
+  build-docs:
+    if: github.repository == 'apache/incubator-pekko-http-quickstart-java.g8'
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java 11
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - name: Cache Coursier cache
+        uses: coursier/cache-action@v6.4.0
+
+      - name: sbt & Paradox
+        run: sbt test docs/paradox

--- a/src/main/g8/pom.xml
+++ b/src/main/g8/pom.xml
@@ -74,8 +74,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.5.1</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/g8/pom.xml
+++ b/src/main/g8/pom.xml
@@ -74,8 +74,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.5.1</version>
                 <configuration>
-                    <source>17</source>
-                    <target>17</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
`sbt paradox` doesn't work with Java 17

we need Java 17 for the Maven/Gradle tests because Java Records are used in the code